### PR TITLE
[GH Actions] Ensure Gradle directories exist in workflow

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -13,6 +13,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: ensure Gradle dirs exist
+        run: mkdir -p ~/.gradle/caches ~/.gradle/wrapper/
+
       - name: Gradle cache
         uses: actions/cache@v4.3.0
         with:


### PR DESCRIPTION
Add step to ensure Gradle directories exist before caching.